### PR TITLE
Accept copy and paste in some fields of GoogleDataSettings

### DIFF
--- a/Assets/QuickSheet/GDataPlugin/Editor/GoogleDataSettingsEditor.cs
+++ b/Assets/QuickSheet/GDataPlugin/Editor/GoogleDataSettingsEditor.cs
@@ -1,7 +1,7 @@
 ﻿///////////////////////////////////////////////////////////////////////////////
 ///
 /// GoogleDataSettingsEditor.cs
-/// 
+///
 /// (c)2013 Kim, Hyoun Woo
 ///
 ///////////////////////////////////////////////////////////////////////////////
@@ -169,13 +169,13 @@ namespace UnityQuickSheet
                 // client_id for OAuth2
                 GUILayout.BeginHorizontal();
                 GUILayout.Label("Client ID: ", GUILayout.Width(LabelWidth));
-                setting.OAuth2Data.client_id = GUILayout.TextField(setting.OAuth2Data.client_id);
+                setting.OAuth2Data.client_id = EditorGUILayout.TextField(setting.OAuth2Data.client_id);
                 GUILayout.EndHorizontal();
 
                 // client_secret for OAuth2
                 GUILayout.BeginHorizontal();
                 GUILayout.Label("Client Secret: ", GUILayout.Width(LabelWidth));
-                setting.OAuth2Data.client_secret = GUILayout.TextField(setting.OAuth2Data.client_secret);
+                setting.OAuth2Data.client_secret = EditorGUILayout.TextField(setting.OAuth2Data.client_secret);
                 GUILayout.EndHorizontal();
 
                 EditorGUILayout.Separator();
@@ -201,12 +201,12 @@ namespace UnityQuickSheet
 
                 GUILayout.BeginHorizontal();
                 GUILayout.Label("Runtime Path: ", GUILayout.Width(LabelWidth));
-                setting.RuntimePath = GUILayout.TextField(setting.RuntimePath);
+                setting.RuntimePath = EditorGUILayout.TextField(setting.RuntimePath);
                 GUILayout.EndHorizontal();
 
                 GUILayout.BeginHorizontal();
                 GUILayout.Label("Editor Path: ", GUILayout.Width(LabelWidth));
-                setting.EditorPath = GUILayout.TextField(setting.EditorPath);
+                setting.EditorPath = EditorGUILayout.TextField(setting.EditorPath);
                 GUILayout.EndHorizontal();
             }
             else


### PR DESCRIPTION
![unity 5 6 4p4 personal 64bit - main unity - unity-quicksheet - pc mac linux standalone _dx9_ 2017-12-10 02 25 32](https://user-images.githubusercontent.com/134377/33797790-6b2c1bd0-dd51-11e7-9d99-109168ebd431.png)

When I have been following Gettting Started, I feel bit hard that I can not paste Client ID/Secret and Runtime/Editor Path from document.
So I want make them pastable.