### PR TITLE
Remove Property.txt from template seems not to be used

### DIFF
--- a/Assets/QuickSheet/ExcelPlugin/Templates/Property.txt
+++ b/Assets/QuickSheet/ExcelPlugin/Templates/Property.txt
@@ -1,4 +1,0 @@
-    [SerializeField]
-    string $FieldName;
-    public string $CapitalFieldName	{ get {return $FieldName; } set { $FieldName = value;} }
-    

--- a/Assets/QuickSheet/ExcelPlugin/Templates/Property.txt.meta
+++ b/Assets/QuickSheet/ExcelPlugin/Templates/Property.txt.meta
@@ -1,4 +1,0 @@
-fileFormatVersion: 2
-guid: 451edb1a2e4132c4ba012a34353b1555
-TextScriptImporter:
-  userData: 

--- a/Assets/QuickSheet/GDataPlugin/Templates/Property.txt
+++ b/Assets/QuickSheet/GDataPlugin/Templates/Property.txt
@@ -1,4 +1,0 @@
-    [SerializeField]
-    string $FieldName;
-    public string $CapitalFieldName	{ get {return $FieldName; } set { $FieldName = value;} }
-    

--- a/Assets/QuickSheet/GDataPlugin/Templates/Property.txt.meta
+++ b/Assets/QuickSheet/GDataPlugin/Templates/Property.txt.meta
@@ -1,4 +1,0 @@
-fileFormatVersion: 2
-guid: 2ed93cb7785260347a2e94fe2b5ef157
-TextScriptImporter:
-  userData: 


### PR DESCRIPTION
```
$ git grep "GetTemplate"
Assets/QuickSheet/Editor/BaseMachineEditor.cs:100:            sp.template = GetTemplate("ScriptableObjectClass");
Assets/QuickSheet/Editor/BaseMachineEditor.cs:144:            sp.template = GetTemplate("ScriptableObjectEditorClass");
Assets/QuickSheet/Editor/BaseMachineEditor.cs:212:            sp.template = GetTemplate("DataClass");
Assets/QuickSheet/Editor/BaseMachineEditor.cs:273:        protected string GetTemplate(string nameWithoutExtension)
Assets/QuickSheet/ExcelPlugin/Editor/ExcelMachineEditor.cs:296:            sp.template = GetTemplate("PostProcessor");
Assets/QuickSheet/GDataPlugin/Editor/GoogleMachineEditor.cs:271:            sp.template = GetTemplate("DataClass");
Assets/QuickSheet/GDataPlugin/Editor/GoogleMachineEditor.cs:292:            sp.template = GetTemplate("AssetFileClass");
```

I have tried to make my custom templates and found that Property.txt is not referred.
The result of `git grep "GetTemplate"` indicates so too.

So I guess Property.txt is not used currently or you have been templatizing it?