### PR TITLE
Initialize TemplatePath when ScriptableObject asset created

### DIFF
--- a/Assets/QuickSheet/ExcelPlugin/Editor/ExcelMachine.cs
+++ b/Assets/QuickSheet/ExcelPlugin/Editor/ExcelMachine.cs
@@ -1,7 +1,7 @@
 ﻿///////////////////////////////////////////////////////////////////////////////
 ///
 /// ExcelMachine.cs
-/// 
+///
 /// (c)2014 Kim, Hyoun Woo
 ///
 ///////////////////////////////////////////////////////////////////////////////
@@ -17,32 +17,29 @@ namespace UnityQuickSheet
     internal class ExcelMachine : BaseMachine
     {
         /// <summary>
-        /// where the .xls or .xlsx file is. The path should start with "Assets/". 
+        /// where the .xls or .xlsx file is. The path should start with "Assets/".
         /// </summary>
         public string excelFilePath;
 
         // both are needed for popup editor control.
         public string[] SheetNames = { "" };
-        public int CurrentSheetIndex 
+        public int CurrentSheetIndex
         {
             get { return currentSelectedSheet; }
-            set { currentSelectedSheet = value;} 
+            set { currentSelectedSheet = value;}
         }
 
         [SerializeField]
         protected int currentSelectedSheet = 0;
 
-        // excel and google plugin have its own template files, 
+        // excel and google plugin have its own template files,
         // so we need to set the different path when the asset file is created.
         private readonly string excelTemplatePath = "QuickSheet/ExcelPlugin/Templates";
 
         /// <summary>
-        /// Note: Called when the asset file is selected.
+        /// Note: Called when the asset file is created.
         /// </summary>
-        protected new void OnEnable()
-        {
-            base.OnEnable();
-
+        private void Awake() {
             TemplatePath = excelTemplatePath;
         }
 

--- a/Assets/QuickSheet/GDataPlugin/Editor/GoogleMachine.cs
+++ b/Assets/QuickSheet/GDataPlugin/Editor/GoogleMachine.cs
@@ -1,7 +1,7 @@
 ﻿///////////////////////////////////////////////////////////////////////////////
 ///
 /// GoogleMachine.cs
-/// 
+///
 /// (c)2013 Kim, Hyoun Woo
 ///
 ///////////////////////////////////////////////////////////////////////////////
@@ -23,19 +23,16 @@ namespace UnityQuickSheet
         [SerializeField]
         public static string assetFileName = "GoogleMachine.asset";
 
-        // excel and google plugin have its own template files, 
+        // excel and google plugin have its own template files,
         // so we need to set the different path when the asset file is created.
         private readonly string gDataTemplatePath = "QuickSheet/GDataPlugin/Templates";
 
         public string AccessCode = "";
 
         /// <summary>
-        /// Note: Called when the asset file is selected.
+        /// Note: Called when the asset file is created.
         /// </summary>
-        protected new void OnEnable()
-        {
-            base.OnEnable();
-
+        private void Awake() {
             TemplatePath = gDataTemplatePath;
         }
 


### PR DESCRIPTION
![5bkpr2o - imgur](https://user-images.githubusercontent.com/134377/33894941-95347e06-dfa2-11e7-8a0d-1529d9105e29.gif)

As far as I know, `ScriptableObject.OnEnable()` is called when Unity detect some scripts created or changed in Unity Editor env.
Also called when an asset of the ScriptableObject is selected first time after starting up Unity Editor.

Because of that behavior, TemplatePath I assign to my custom templates folder is always reset to `QuickSheet/GDataPlugin/Templates` described in gif animation.
So I have replaced `OnEnable()` with `Awake()`.