### PR TITLE
Fixed NullReferenceException.

### DIFF
--- a/Assets/QuickSheet/ExcelPlugin/Editor/ExcelMachine.cs
+++ b/Assets/QuickSheet/ExcelPlugin/Editor/ExcelMachine.cs
@@ -38,9 +38,12 @@ namespace UnityQuickSheet
         /// </summary>
 
         private void Awake() {
-            // excel and google plugin have its own template files,
-            // so we need to set the different path when the asset file is created.
-            TemplatePath = ExcelSettings.Instance.TemplatePath;
+            if (ExcelSettings.Instance != null)
+            {
+                // excel and google plugin have its own template files,
+                // so we need to set the different path when the asset file is created.
+                TemplatePath = ExcelSettings.Instance.TemplatePath;
+            }
         }
 
         /// <summary>

--- a/Assets/QuickSheet/ExcelPlugin/Editor/ExcelMachineEditor.cs
+++ b/Assets/QuickSheet/ExcelPlugin/Editor/ExcelMachineEditor.cs
@@ -25,7 +25,7 @@ namespace UnityQuickSheet
             base.OnEnable();
 
             machine = target as ExcelMachine;
-            if (machine != null)
+            if (machine != null && ExcelSettings.Instance != null)
             {
                 if (string.IsNullOrEmpty(ExcelSettings.Instance.RuntimePath) == false)
                     machine.RuntimeClassPath = ExcelSettings.Instance.RuntimePath;


### PR DESCRIPTION
The NullReferenceException occurs when the user creates an Excel Tool
(ExcelMachine) asset file before an Excel Setting asset file is created.