### PR TITLE
Allowed empty cells for non-enum array types in Google Spreadsheets.

### DIFF
--- a/Assets/QuickSheet/GDataPlugin/Editor/GDataDB/GDataDB/Impl/Serializer.cs
+++ b/Assets/QuickSheet/GDataPlugin/Editor/GDataDB/GDataDB/Impl/Serializer.cs
@@ -95,17 +95,19 @@ namespace GDataDB.Impl {
                                 char[] charToTrim = { ',', ' ' };
                                 str = str.TrimEnd(charToTrim);
 
-                                // split by ','
-                                object[] temp = str.Split(DELIMETER);
+                                if (!string.IsNullOrEmpty(str)) {
+                                    // split by ','
+                                    object[] temp = str.Split(DELIMETER);
 
-                                Array array = (Array)Activator.CreateInstance(property.PropertyType, temp.Length);
+                                    Array array = (Array)Activator.CreateInstance(property.PropertyType, temp.Length);
 
-                                for (int i = 0; i < array.Length; i++) 
-                                {
-                                    array.SetValue(Convert.ChangeType(temp[i], property.PropertyType.GetElementType()), i);
+                                    for (int i = 0; i < array.Length; i++)
+                                    {
+                                        array.SetValue(Convert.ChangeType(temp[i], property.PropertyType.GetElementType()), i);
+                                    }
+
+                                    property.SetValue(r, array, null);
                                 }
-
-                                property.SetValue(r, array, null);
                             }
                         } 
                         else 


### PR DESCRIPTION
The generated data classes already have array type fields be initialized as zero length arrays instead of null. Therefore, we can safely ignore an array type cell in a spreadsheet if the cell value is empty.