### PR TITLE
Fix Editor foldout small triangle does not work in Unity 2019 3.0

### DIFF
--- a/Assets/QuickSheet/Editor/GUIHelper.cs
+++ b/Assets/QuickSheet/Editor/GUIHelper.cs
@@ -41,7 +41,7 @@ namespace UnityQuickSheet
             {
                 case SerializedPropertyType.Generic:
                     // make Array and Object to be fold
-                    prop.isExpanded = EditorGUILayout.Foldout(prop.isExpanded, prop.displayName);
+                    prop.isExpanded = EditorGUILayout.Foldout(prop.isExpanded, prop.displayName, true);
                     if (!prop.isExpanded)
                         break;
 


### PR DESCRIPTION
Fix issue #74 