### PR TITLE
Fixed the bug that GUIHelper.DrawSerializedProperty didn't update properly in Unity 2019.3.15f1 so couldn't get the data.

### DIFF
--- a/Assets/QuickSheet/Editor/BaseEditor.cs
+++ b/Assets/QuickSheet/Editor/BaseEditor.cs
@@ -24,7 +24,6 @@ namespace UnityQuickSheet
         protected SerializedProperty serializedData;
 
         protected GUIStyle box;
-        protected bool isGUISkinInitialized = false;
 
         /// <summary>
         /// Create SerialliedObject and initialize related SerializedProperty objects 
@@ -49,39 +48,16 @@ namespace UnityQuickSheet
         }
 
         /// <summary>
-        /// Create and initialize a new gui style which can be used for representing 
-        /// each element of dataArray.
-        /// </summary>
-        protected void InitGUIStyle()
-        {
-            box = new GUIStyle("box");
-            box.normal.background = Resources.Load(EditorGUIUtility.isProSkin ? "brown" : "lightSkinBox", typeof(Texture2D)) as Texture2D;
-            box.border = new RectOffset(4, 4, 4, 4);
-            box.margin = new RectOffset(3, 3, 3, 3);
-            box.padding = new RectOffset(4, 4, 4, 4);
-        }
-
-        /// <summary>
         /// Draw serialized properties on the Inspector view.
         /// </summary>
         /// <param name="useGUIStyle"></param>
         protected void DrawInspector(bool useGUIStyle = true)
         {
             // Draw 'spreadsheet' and 'worksheet' name.
-            EditorGUILayout.TextField(spreadsheetProp.name, spreadsheetProp.stringValue);
-            EditorGUILayout.TextField(worksheetProp.name, worksheetProp.stringValue);
+            EditorGUILayout.PropertyField(spreadsheetProp);
+            EditorGUILayout.PropertyField(worksheetProp);
 
-            // Draw properties of the data class.
-            if (useGUIStyle && !isGUISkinInitialized)
-            {
-                isGUISkinInitialized = true;
-                InitGUIStyle();
-            }
-
-            if (useGUIStyle)
-                GUIHelper.DrawSerializedProperty(serializedData, box);
-            else
-                GUIHelper.DrawSerializedProperty(serializedData);
+            EditorGUILayout.PropertyField(serializedData, true);
         }
 
         /// <summary>


### PR DESCRIPTION
In Unity 2019.3.15f1 (Not sure about the latest version), GUIHelper.DrawSerializedProperty seems to have some kind of bugs cause the UI can't update. The targetData in the custom Load() function have gotten the data array, but the UI didn't update and save.

So I deprecated the GUIHelper.DrawSerializedProperty and use Unity's original function "EditorGUILayout.PropertyField". 

Aslo I use PropertyField to make user can modify spreadsheet and worksheet's name in SheetData.